### PR TITLE
fix "start" parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,12 +17,16 @@ module.exports = function indexOf(arr, ele, start) {
     ? (len + start)
     : start;
 
-  while (len--) {
-    if (arr[i++] === ele) {
-      idx = i - 1;
-      break;
-    }
+  if (i >= arr.length) {
+    return -1;
   }
 
-  return idx;
+  while (i < len) {
+    if (arr[i] === ele) {
+      return i;
+    }
+    i++;
+  }
+
+  return -1;
 };

--- a/test.js
+++ b/test.js
@@ -18,11 +18,18 @@ describe('indexOf', function () {
     indexOf(['a', 'b', 'c'], 'c').should.equal(2);
   });
 
+  it('should return -1 if fromIndex is out of range:', function () {
+    indexOf(['a', undefined, 'b', 'c', 'a'], undefined, 0).should.equal(1);
+  });
+
   it('should return -1 if the element does not exist:', function () {
     indexOf(['a', 'b', 'c'], 'd').should.equal(-1);
   });
 
   it('should get the index, starting from the given index:', function () {
     indexOf(['a', 'b', 'c', 'a', 'b', 'c'], 'b', 2).should.equal(4);
+    indexOf(['a', undefined, 'b', 'c', 'a'], undefined, 0).should.equal(1);
+    indexOf(['a', undefined, 'b', 'c', 'a'], undefined, 1).should.equal(1);
+    indexOf(['a', undefined, 'b', 'c', 'a'], undefined, 2).should.equal(-1);
   });
 });

--- a/test.js
+++ b/test.js
@@ -19,7 +19,7 @@ describe('indexOf', function () {
   });
 
   it('should return -1 if fromIndex is out of range:', function () {
-    indexOf(['a', undefined, 'b', 'c', 'a'], undefined, 0).should.equal(1);
+    indexOf(['a', undefined, 'b', 'c', 'a'], undefined, 5).should.equal(-1);
   });
 
   it('should return -1 if the element does not exist:', function () {


### PR DESCRIPTION
Currently it fails on these tests:

``` js
t.equal( indexOf(['a', undefined, 'b', 'c', 'a'], undefined, 10), -1 ) 
// expected: -1
// actual: 10

t.equal( indexOf(['a', undefined, 'b', 'c', 'a'], undefined, 2), -1 )  
// expected: -1
// actual: 5
```

[reference](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf)
